### PR TITLE
common_val: bound-safe val_mem_copy API to prevent overflow\n\n- Chan…

### DIFF
--- a/inc/val_common_framework.h
+++ b/inc/val_common_framework.h
@@ -35,6 +35,12 @@ void val_handle_reboot_result(uint32_t test_progress);
 void val_update_regression_report(uint32_t test_result, regre_report_t *regre_report);
 void val_print_regression_report(regre_report_t *regre_report);
 
-void val_mem_copy(char *dest, const char *src, size_t len);
+/*
+ * Safe memory copy with overlap handling (memmove semantics).
+ * Copies up to the minimum of `len` and `dest_sz` bytes from `src` to `dest`.
+ * Returns the number of bytes actually copied. If either pointer is NULL or
+ * `dest_sz` is zero, no bytes are copied and 0 is returned.
+ */
+size_t val_mem_copy(char *dest, size_t dest_sz, const char *src, size_t len);
 
 #endif /* VAL_COMMON_FRAMEWORK_H */

--- a/src/val_common_framework.c
+++ b/src/val_common_framework.c
@@ -168,14 +168,42 @@ void val_print_regression_report(regre_report_t *regre_report)
 }
 
 /**
- *  @brief   -  Copies 'len' bytes from source to destination buffer
- *  @param   -  dest : Destination buffer
- *           -  src  : Source buffer
- *           -  len  : Number of bytes to copy
- *  @return  -  void
+ *  @brief   -  Copies up to min(len, dest_sz) bytes from source to destination safely
+ *             -  Handles overlapping regions like memmove
+ *  @param   -  dest     : Destination buffer
+ *           -  dest_sz  : Destination buffer capacity in bytes
+ *           -  src      : Source buffer
+ *           -  len      : Requested number of bytes to copy
+ *  @return  -  Number of bytes actually copied
  */
-void val_mem_copy(char *dest, const char *src, size_t len)
+size_t val_mem_copy(char *dest, size_t dest_sz, const char *src, size_t len)
 {
-    for (size_t i = 0; i < len; ++i)
-        dest[i] = src[i];
+    /* Gracefully handle trivial or invalid cases */
+    if (dest == NULL || src == NULL || dest_sz == 0 || len == 0 || dest == src)
+        return 0;
+
+    size_t n = (len < dest_sz) ? len : dest_sz;
+
+    /* If regions overlap and dest is higher, copy backwards to avoid clobbering */
+    if ((src < dest) && (dest < (src + n)))
+    {
+        const char *s = src + n;
+        char *d = dest + n;
+        while (n--)
+        {
+            *--d = *--s;
+        }
+    }
+    else
+    {
+        /* Non-overlapping or dest before src: copy forwards */
+        const char *s = src;
+        char *d = dest;
+        while (n--)
+        {
+            *d++ = *s++;
+        }
+    }
+
+    return (len < dest_sz) ? len : dest_sz;
 }

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -632,10 +632,19 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 
         if (len > 0 && msg[len - 1] == '\n')
         {
-            val_mem_copy(formatted_msg, msg, len - 1);
-            formatted_msg[len - 1] = '\r';
-            formatted_msg[len] = '\n';
-            formatted_msg[len + 1] = '\0';
+            /* Copy message excluding trailing '\n', then append "\r\n" and NUL. */
+            size_t copied = val_mem_copy(formatted_msg, sizeof(formatted_msg), msg, len - 1);
+            /* Ensure there is room for CRLF and NUL; truncate gracefully if needed. */
+            size_t tail = copied;
+            if (tail + 2 < sizeof(formatted_msg)) {
+                formatted_msg[tail] = '\r';
+                formatted_msg[tail + 1] = '\n';
+                formatted_msg[tail + 2] = '\0';
+            } else if (tail < sizeof(formatted_msg)) {
+                /* Best-effort termination if near the end of the buffer. */
+                /* Guarantee NUL-termination even if we cannot append CRLF fully. */
+                formatted_msg[sizeof(formatted_msg) - 1] = '\0';
+            }
 
             chars_written = val_log(formatted_msg, args);
             lastWasNewline = true;


### PR DESCRIPTION
…ge signature to include destination size and return bytes copied\n- Implement memmove-style copy with size clamp and NULL/zero guards\n- Update call site in val_common_log to use new API and ensure termination\n\nFixes: potential buffer overflow due to unconstrained copy\nChange-Id: I6F4C2E1D9A7B3C5F1E2A4D7C9B0A8E3F