### PR TITLE
val_printf: guard against NULL format string to prevent dereference\n…

### DIFF
--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -465,6 +465,10 @@ static size_t val_log(const char *fmt, va_list args)
 
             case 's': {
                 char *str = va_arg(args, char *);
+                /* Safely handle NULL string arguments for %s */
+                if (str == NULL) {
+                    str = "(null)";
+                }
 
                 fmt++;
                 chars_written += print_string(

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -588,6 +588,11 @@ out:
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     size_t chars_written = 0;
+    /* Guard against NULL format strings to avoid dereferencing NULL. */
+    if (msg == NULL) {
+        return 0;
+    }
+
     size_t len = log_strnlen_s(msg, LOG_MAX_STRING_LENGTH - 2);
     static bool lastWasNewline = true;
     char formatted_msg[LOG_MAX_STRING_LENGTH];


### PR DESCRIPTION
…\nReturn 0 early if format string is NULL instead of passing it to\nval_log. This avoids a potential NULL pointer dereference when callers\naccidentally pass NULL.\n\nFixes: potential null deref of 'msg' in val_log path