### PR TITLE
Handle NULL msg in val_printf

### DIFF
--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -588,6 +588,12 @@ out:
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     size_t chars_written = 0;
+    static const char null_msg[] = "<NULL>";
+
+    if (msg == NULL) {
+        msg = null_msg;
+    }
+
     size_t len = log_strnlen_s(msg, LOG_MAX_STRING_LENGTH - 2);
     static bool lastWasNewline = true;
     char formatted_msg[LOG_MAX_STRING_LENGTH];


### PR DESCRIPTION
## Summary
- prevent val_printf from dereferencing a NULL format string by substituting a safe placeholder

## Testing
- not run (not requested)
