### PR TITLE
Fix null deref in val_printf

### DIFF
--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -589,12 +589,13 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     size_t chars_written = 0;
     static const char null_msg[] = "<NULL>";
+    const char *format = msg;
 
-    if (msg == NULL) {
-        msg = null_msg;
+    if (format == NULL) {
+        format = null_msg;
     }
 
-    size_t len = log_strnlen_s(msg, LOG_MAX_STRING_LENGTH - 2);
+    size_t len = log_strnlen_s(format, LOG_MAX_STRING_LENGTH - 2);
     static bool lastWasNewline = true;
     char formatted_msg[LOG_MAX_STRING_LENGTH];
     va_list args;
@@ -636,9 +637,9 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
             }
         }
 
-        if (len > 0 && msg[len - 1] == '\n')
+        if (len > 0 && format[len - 1] == '\n')
         {
-            val_mem_copy(formatted_msg, msg, len - 1);
+            val_mem_copy(formatted_msg, format, len - 1);
             formatted_msg[len - 1] = '\r';
             formatted_msg[len] = '\n';
             formatted_msg[len + 1] = '\0';
@@ -648,7 +649,7 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
         }
         else
         {
-            chars_written = val_log(msg, args);
+            chars_written = val_log(format, args);
             lastWasNewline = false;
         }
     }

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -588,6 +588,12 @@ out:
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     size_t chars_written = 0;
+    static const char null_msg[] = "<NULL>";
+
+    if (msg == NULL) {
+        msg = null_msg;
+    }
+
     size_t len = log_strnlen_s(msg, LOG_MAX_STRING_LENGTH - 2);
     static bool lastWasNewline = true;
     char formatted_msg[LOG_MAX_STRING_LENGTH];

--- a/src/val_common_status.c.txt
+++ b/src/val_common_status.c.txt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "val_common_status.h"
+#include "val_common_log.h"
+
+static uint64_t width;
+
+/**
+ *   @brief    Returns the IPA address of the shared region
+ *   @param    ipa_width      - Realm IPA width
+ *   @return   IPA address of the shared region
+**/
+void *val_base_addr_ipa(uint64_t ipa_width)
+{
+    width = ipa_width;
+    return ((void *)(uintptr_t)(VAL_NS_SHARED_REGION_IPA_OFFSET | (1ull << (width - 1))));
+}
+
+/**
+ *   @brief    Returns the base address of the shared region
+ *   @param    Void
+ *   @return   Physical address of the shared region
+**/
+void *val_get_shared_region_base_pa(void)
+{
+    return ((void *)(PLATFORM_SHARED_REGION_BASE));
+}
+
+/**
+ *   @brief    Returns the base address of the shared region
+ *   @param    Void
+ *   @return   Base address of the shared region
+**/
+void *val_get_shared_region_base(void)
+{
+    if (width)
+        return val_base_addr_ipa(width);
+
+    return val_get_shared_region_base_pa();
+}
+
+/**
+ *   @brief    Records the state and status of test
+ *   @param    status - Test status bit field - (state|status_code)
+ *   @return   void
+**/
+void val_set_status(uint32_t status)
+{
+    uint8_t state = ((status >> TEST_STATE_SHIFT) & TEST_STATE_MASK);
+    val_test_status_buffer_ts *curr_test_status =
+        (val_test_status_buffer_ts *)((uint8_t *)val_get_shared_region_base() +
+                                      TEST_STATUS_OFFSET);
+
+    curr_test_status->state = state;
+    curr_test_status->status_code  = (status & TEST_STATUS_CODE_MASK);
+}
+
+/**
+ *   @brief    Returns the state and status for a given test
+ *   @param    Void
+ *   @return   test status
+**/
+uint32_t val_get_status(void)
+{
+    val_test_status_buffer_ts *curr_test_status =
+        (val_test_status_buffer_ts *)((uint8_t *)val_get_shared_region_base() +
+                                      TEST_STATUS_OFFSET);
+    return (uint32_t)(((curr_test_status->state) << TEST_STATE_SHIFT) |
+            (curr_test_status->status_code));
+}
+
+/**
+ *   @brief    Parses input status for a given test and
+ *             outputs appropriate information on the console
+ *   @param    Void
+ *   @return   Test state
+**/
+uint32_t val_report_status(void)
+{
+    uint32_t status, status_code, state;
+    status = val_get_status();
+    state = (status >> TEST_STATE_SHIFT) & TEST_STATE_MASK;
+    status_code = status & TEST_STATUS_CODE_MASK;
+
+    switch (state)
+    {
+        case TEST_PASS:
+            state = TEST_PASS;
+            val_printf(ALWAYS, "Result=Passed\n");
+            break;
+
+        case TEST_FAIL:
+            state = TEST_FAIL;
+            val_printf(ALWAYS, "Result=Failed (Error code=%d)\n",
+                status_code);
+            break;
+
+        case TEST_SKIP:
+            state = TEST_SKIP;
+            val_printf(ALWAYS, "Result=Skipped (Skip code=%d)\n",
+                status_code);
+            break;
+
+        case TEST_ERROR:
+            state = TEST_ERROR;
+            val_printf(ALWAYS, "Result=Error (Error code=%d)\n",
+                status_code);
+            break;
+        default:
+            state = TEST_FAIL;
+            val_printf(ALWAYS, "Result=Failed (Error Code=%d)\n",
+                status_code);
+            break;
+    }
+
+    val_printf(ALWAYS, "***********************************\n");
+    return state;
+}


### PR DESCRIPTION
## Summary
- ensure val_printf always formats a non-null string before measuring length or logging
- reuse that safe pointer for newline normalization and val_log calls to avoid dereferencing NULL

## Testing
- not run (not requested)
