### PR TITLE
Fix null dereference in val_printf

### DIFF
--- a/inc/val_common_log.h
+++ b/inc/val_common_log.h
@@ -27,6 +27,14 @@ typedef enum {
  *   @param    - ...        : ellipses for variadic args
  *   @return   - SUCCESS((Any positive number for character written)/FAILURE(0))
 **/
-uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...);
+#if defined(__GNUC__) || defined(__clang__)
+#define VAL_PRINTF_ATTR __attribute__((format(printf, 2, 3)))
+#else
+#define VAL_PRINTF_ATTR
+#endif
+
+uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...) VAL_PRINTF_ATTR;
+
+#undef VAL_PRINTF_ATTR
 
 #endif /* VAL_COMMON_LOG_H */

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -588,11 +588,18 @@ out:
 uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 {
     size_t chars_written = 0;
-    size_t len = log_strnlen_s(msg, LOG_MAX_STRING_LENGTH - 2);
+    static const char null_msg[] = "<NULL>";
+    const char *format = msg;
+    size_t len;
     static bool lastWasNewline = true;
     char formatted_msg[LOG_MAX_STRING_LENGTH];
     va_list args;
 
+    if (format == NULL) {
+        format = null_msg;
+    }
+
+    len = log_strnlen_s(format, LOG_MAX_STRING_LENGTH - 2);
     va_start(args, msg);
 
     if (verbosity >= VERBOSITY)
@@ -630,9 +637,9 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
             }
         }
 
-        if (len > 0 && msg[len - 1] == '\n')
+        if (len > 0 && format[len - 1] == '\n')
         {
-            val_mem_copy(formatted_msg, msg, len - 1);
+            val_mem_copy(formatted_msg, format, len - 1);
             formatted_msg[len - 1] = '\r';
             formatted_msg[len] = '\n';
             formatted_msg[len + 1] = '\0';
@@ -642,7 +649,7 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
         }
         else
         {
-            chars_written = val_log(msg, args);
+            chars_written = val_log(format, args);
             lastWasNewline = false;
         }
     }


### PR DESCRIPTION
## Summary
- guard the val_printf format string so NULL calls use a literal placeholder
- route all subsequent string handling through the guarded pointer to avoid dereferences

## Testing
- not run (not available in repo)