### PR TITLE
Guard %s formatting against NULL strings

### DIFF
--- a/inc/val_common_log.h
+++ b/inc/val_common_log.h
@@ -27,6 +27,14 @@ typedef enum {
  *   @param    - ...        : ellipses for variadic args
  *   @return   - SUCCESS((Any positive number for character written)/FAILURE(0))
 **/
-uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...);
+#if defined(__GNUC__) || defined(__clang__)
+#define VAL_PRINTF_ATTR __attribute__((format(printf, 2, 3)))
+#else
+#define VAL_PRINTF_ATTR
+#endif
+
+uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...) VAL_PRINTF_ATTR;
+
+#undef VAL_PRINTF_ATTR
 
 #endif /* VAL_COMMON_LOG_H */

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -464,7 +464,8 @@ static size_t val_log(const char *fmt, va_list args)
             }
 
             case 's': {
-                char *str = va_arg(args, char *);
+                char *arg = va_arg(args, char *);
+                const char *str = arg ? arg : "(null)";
 
                 fmt++;
                 chars_written += print_string(


### PR DESCRIPTION
## Summary
- guard %s arguments in val_printf so NULL strings never reach the formatter internals
- default to the literal '(null)' so logs remain deterministic without dereferencing NULL

## Testing
- not run (no automated targets available)