### PR TITLE
Guard val_mem_copy against buffer overflow

### DIFF
--- a/inc/val_common_framework.h
+++ b/inc/val_common_framework.h
@@ -35,6 +35,6 @@ void val_handle_reboot_result(uint32_t test_progress);
 void val_update_regression_report(uint32_t test_result, regre_report_t *regre_report);
 void val_print_regression_report(regre_report_t *regre_report);
 
-void val_mem_copy(char *dest, const char *src, size_t len);
+void val_mem_copy(char *dest, size_t dest_size, const char *src, size_t len);
 
 #endif /* VAL_COMMON_FRAMEWORK_H */

--- a/inc/val_common_log.h
+++ b/inc/val_common_log.h
@@ -27,6 +27,14 @@ typedef enum {
  *   @param    - ...        : ellipses for variadic args
  *   @return   - SUCCESS((Any positive number for character written)/FAILURE(0))
 **/
-uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...);
+#if defined(__GNUC__) || defined(__clang__)
+#define VAL_PRINTF_ATTR __attribute__((format(printf, 2, 3)))
+#else
+#define VAL_PRINTF_ATTR
+#endif
+
+uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...) VAL_PRINTF_ATTR;
+
+#undef VAL_PRINTF_ATTR
 
 #endif /* VAL_COMMON_LOG_H */

--- a/src/val_common_framework.c
+++ b/src/val_common_framework.c
@@ -168,14 +168,21 @@ void val_print_regression_report(regre_report_t *regre_report)
 }
 
 /**
- *  @brief   -  Copies 'len' bytes from source to destination buffer
- *  @param   -  dest : Destination buffer
- *           -  src  : Source buffer
- *           -  len  : Number of bytes to copy
+ *  @brief   -  Copies 'len' bytes from source to destination buffer safely
+ *  @param   -  dest      : Destination buffer
+ *           -  dest_size : Size of the destination buffer
+ *           -  src       : Source buffer
+ *           -  len       : Number of bytes to copy
  *  @return  -  void
  */
-void val_mem_copy(char *dest, const char *src, size_t len)
+void val_mem_copy(char *dest, size_t dest_size, const char *src, size_t len)
 {
+    if (dest == NULL || src == NULL || dest_size == 0 || len == 0)
+        return;
+
+    if (len > dest_size)
+        len = dest_size; /* Clamp to prevent writing past dest */
+
     for (size_t i = 0; i < len; ++i)
         dest[i] = src[i];
 }

--- a/src/val_common_log.c
+++ b/src/val_common_log.c
@@ -632,7 +632,7 @@ uint32_t val_printf(print_verbosity_t verbosity, const char *msg, ...)
 
         if (len > 0 && msg[len - 1] == '\n')
         {
-            val_mem_copy(formatted_msg, msg, len - 1);
+            val_mem_copy(formatted_msg, sizeof(formatted_msg), msg, len - 1);
             formatted_msg[len - 1] = '\r';
             formatted_msg[len] = '\n';
             formatted_msg[len + 1] = '\0';


### PR DESCRIPTION
## Summary
- add a destination-size parameter to val_mem_copy and clamp copies to it
- update the only caller to pass the buffer span

## Testing
- Not run (not requested)
